### PR TITLE
解决1倍图不设置background-size问题

### DIFF
--- a/index.js
+++ b/index.js
@@ -644,14 +644,12 @@ function updateReferences(images, options, sprites, css) {
 
 					backgroundImage.after(backgroundPosition);
 
-					if (image.ratio > 1) {
-						backgroundSize = postcss.decl({
-							prop: 'background-size',
-							value: getBackgroundSize(image)
-						});
+          backgroundSize = postcss.decl({
+            prop: 'background-size',
+            value: getBackgroundSize(image)
+          });
 
-						backgroundPosition.after(backgroundSize);
-					}
+          backgroundPosition.after(backgroundSize);
 				}
 			}
 		});


### PR DESCRIPTION
解决1倍图不设置background-size问题,为了解决精灵图在rem的兼容